### PR TITLE
this makes ./gradlew build fail for me

### DIFF
--- a/src/main/groovy/HelloWorldPlugin.groovy
+++ b/src/main/groovy/HelloWorldPlugin.groovy
@@ -4,11 +4,17 @@ import org.gradle.api.tasks.GradleBuild
  
 class HelloWorldPlugin implements Plugin<Project> {     
     void apply(Project project) {     
+        project.task('doWork') {
+            doLast {
+                println 'Hello world!'
+            }
+        }
         def externalBuildFile = new File(project.getProperty('externalBuildFile'))
         
         project.task('invokeExternalBuild', type: GradleBuild) {
-            buildFile = externalBuildFile
-            tasks = ['helloWorld']
+            //buildFile = externalBuildFile
+            //tasks = ['helloWorld']
+            tasks = ['doWork']
         }
     }
 }


### PR DESCRIPTION
Related to https://discuss.gradle.org/t/using-gradlerunner-to-test-a-plugin-with-gradlebuild-tasks/18167

Here's the test result:

``````
org.gradle.testkit.runner.UnexpectedBuildFailure: Unexpected build execution failure in /var/folders/dn/0rbsn8cs25l0yzczh63yyw4r0000gp/T/junit2235470424896308816 with arguments [invokeExternalBuild, -PexternalBuildFile=/Users/david.byron/src/gradle-testkit-gradlebuild/helloworld.gradle]

Output:
:invokeExternalBuild FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/private/var/folders/dn/0rbsn8cs25l0yzczh63yyw4r0000gp/T/junit1930998405706082549/build.gradle' line: 3

* What went wrong:
Plugin [id: 'my.company.helloworld'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Gradle Central Plugin Repository (plugin dependency must include a version number for this source)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 1.861 secs

    at org.gradle.testkit.runner.internal.DefaultGradleRunner$1.execute(DefaultGradleRunner.java:222)
    at org.gradle.testkit.runner.internal.DefaultGradleRunner$1.execute(DefaultGradleRunner.java:219)
    at org.gradle.testkit.runner.internal.DefaultGradleRunner.run(DefaultGradleRunner.java:282)
    at org.gradle.testkit.runner.internal.DefaultGradleRunner.build(DefaultGradleRunner.java:219)
    at HelloWorldPluginTest.external build prints hello world(HelloWorldPluginTest.groovy:35)```
``````
